### PR TITLE
Fixed broken URL of npm install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Node.js is required for the static asset pipeline. If you don't already have it,
 
 ```
 brew install node
-curl https://npmjs.org/install.sh | sh
+curl https://www.npmjs.org/install.sh | sh
 ```
 
 Then install the project requirements:


### PR DESCRIPTION
Without the `www`, the shell returns a syntax error that reveals an HTTP 301 redirect. The script works with the `www` added to the URL.
