### PR TITLE
change version of jdcal to 1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cssmin==0.1.4
 docutils==0.11
 dulwich==0.9.4
 envoy==0.0.2
-jdcal==1.0
+jdcal==1.0.1
 jmespath==0.2.1
 nose==1.2.1
 odict==1.5.1


### PR DESCRIPTION
Running `pip install -r requirements.txt` for the first time, it fails with error message
```
Could not find a version that satisfies the requirement jdcal==1.0 (from -r requirements.txt (line 15)) (from versions: 1.0.1, 1.2, 1.3)
No matching distribution found for jdcal==1.0 (from -r requirements.txt (line 15))
```

This change remove the error. 

https://github.com/phn/jdcal/issues/5

Thanks!
Daigo Fujiwara,
WBUR Boston